### PR TITLE
Adding support for the Lumen framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,22 @@ For [**Laravel 4.1 or 4.2**](http://laravel.com/docs/4.2) supports see [Authorit
 #### Lumen Support
 For Lumen support, follow the instructions below for the most part, but as Lumen doesn't support config publishing you'll not be able to run php artisan vendor:publish for example, and some of the config is done a little different.
 
-You will need to manually copy the migrations in to your migrations folder from vendor/efficiently/authority-controller/src/migrations/ to your migrations folder and the config from vendor/efficiently/authority-controller/src/config/config.php to config/authority-controller.php.
-
+You will need to manually copy the migrations in to your migrations folder from
+ ```php
+ vendor/efficiently/authority-controller/src/migrations/ to your migrations folder and the config from vendor/efficiently/authority-controller/src/config/config.php to config/authority-controller.php.
+ ```
 Register the aliases (in bootstrap/app.php), notice you'll need to add the Lang alias too.
 
-class_alias('Efficiently\AuthorityController\Facades\Params', 'Params');
-class_alias('Efficiently\AuthorityController\Facades\Authority', 'Authority');
-class_alias('Illuminate\Support\Facades\Lang', 'Lang');
-
+ ```php
+ class_alias('Efficiently\AuthorityController\Facades\Params', 'Params');
+ class_alias('Efficiently\AuthorityController\Facades\Authority', 'Authority');
+ class_alias('Illuminate\Support\Facades\Lang', 'Lang');
+ ```
 Lumen will not automatically load the config file so this will need adding to bootstrap/app.php too
 
-$app->configure('authority-controller');
-
+ ```php
+ $app->configure('authority-controller');
+ ```
 #### Demo application
 
 You can see in action this package with this Laravel 5.1 [**demo application**](https://github.com/efficiently/laravel_authority-controller_app#readme).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AuthorityController [![Build Status](https://travis-ci.org/efficiently/authority-controller.png?branch=master)](http://travis-ci.org/efficiently/authority-controller)
 ===================
 
-AuthorityController is an PHP authorization library for [Laravel 5.0 & 5.1](http://laravel.com) and [Lumen (http://lumen.laravel.com/)] which restricts what resources a given user is allowed to access.
+AuthorityController is an PHP authorization library for [Laravel 5.0 & 5.1](http://laravel.com) and [Lumen] (http://lumen.laravel.com/) which restricts what resources a given user is allowed to access.
 
 All permissions are defined in a single location:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AuthorityController [![Build Status](https://travis-ci.org/efficiently/authority-controller.png?branch=master)](http://travis-ci.org/efficiently/authority-controller)
 ===================
 
-AuthorityController is an PHP authorization library for [Laravel 5.0 & 5.1](http://laravel.com) which restricts what resources a given user is allowed to access.
+AuthorityController is an PHP authorization library for [Laravel 5.0 & 5.1](http://laravel.com) and [Lumen (http://lumen.laravel.com/)] which restricts what resources a given user is allowed to access.
 
 All permissions are defined in a single location:
 
@@ -10,6 +10,21 @@ All permissions are defined in a single location:
 and not duplicated across controllers, routes, views, and database queries.
 
 For [**Laravel 4.1 or 4.2**](http://laravel.com/docs/4.2) supports see [AuthorityController 1.2 branch](https://github.com/efficiently/authority-controller/tree/1.2)
+
+#### Lumen Support
+For Lumen support, follow the instructions below for the most part, but as Lumen doesn't support config publishing you'll not be able to run php artisan vendor:publish for example, and some of the config is done a little different.
+
+You will need to manually copy the migrations in to your migrations folder from vendor/efficiently/authority-controller/src/migrations/ to your migrations folder and the config from vendor/efficiently/authority-controller/src/config/config.php to config/authority-controller.php.
+
+Register the aliases (in bootstrap/app.php), notice you'll need to add the Lang alias too.
+
+class_alias('Efficiently\AuthorityController\Facades\Params', 'Params');
+class_alias('Efficiently\AuthorityController\Facades\Authority', 'Authority');
+class_alias('Illuminate\Support\Facades\Lang', 'Lang');
+
+Lumen will not automatically load the config file so this will need adding to bootstrap/app.php too
+
+$app->configure('authority-controller');
 
 #### Demo application
 

--- a/src/Efficiently/AuthorityController/AuthorityControllerServiceProvider.php
+++ b/src/Efficiently/AuthorityController/AuthorityControllerServiceProvider.php
@@ -40,7 +40,6 @@ class AuthorityControllerServiceProvider extends ServiceProvider
             ], 'translations');
         }
 
-
         // Load translations
         $this->loadTranslationsFrom(__DIR__ . '/../../lang', 'authority-controller');
     }

--- a/src/Efficiently/AuthorityController/AuthorityControllerServiceProvider.php
+++ b/src/Efficiently/AuthorityController/AuthorityControllerServiceProvider.php
@@ -22,23 +22,27 @@ class AuthorityControllerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        // Publish config
-        $this->publishes([
-            __DIR__ . '/../../config/config.php' => config_path('authority-controller.php')
-        ], 'config');
+        //Lumen doesn't support publishing config
+        if (!str_contains($this->app->version(), 'Lumen')) {
+            // Publish config
+            $this->publishes([
+                __DIR__ . '/../../config/config.php' => config_path('authority-controller.php')
+            ], 'config');
 
-        // Publish migrations
-        $this->publishes([
-            __DIR__ . '/../../migrations/' => base_path('database/migrations')
-        ], 'migrations');
+            // Publish migrations
+            $this->publishes([
+                __DIR__ . '/../../migrations/' => base_path('database/migrations')
+            ], 'migrations');
+
+            // Publish translations
+            $this->publishes([
+                __DIR__ . '/../../translations' => base_path('resources/lang')
+            ], 'translations');
+        }
+
 
         // Load translations
         $this->loadTranslationsFrom(__DIR__ . '/../../lang', 'authority-controller');
-
-        // Publish translations
-        $this->publishes([
-            __DIR__ . '/../../translations' => base_path('resources/lang')
-        ], 'translations');
     }
 
     /**


### PR DESCRIPTION
Lumen is a cut down framework based on Laravel and authority-controller doesn't work out of the box with it due to one reason, Lumen doesn't support publishing configuration. This PR addresses that and adds documentation on using it with Lumen.